### PR TITLE
refactor docker-tests.sh

### DIFF
--- a/.docker/docker-compose-balanced-pharo-date.yml
+++ b/.docker/docker-compose-balanced-pharo-date.yml
@@ -3,19 +3,23 @@ services:
   date:
     image: pharo-date:sut
     labels:
-      traefik.port: 8080
-      traefik.frontend.rule: "HostRegexp:{catchall:.*}" # Match all requests
+      traefik.enable: 'true'
+      traefik.http.routers.date.rule: "HostRegexp:{catchall:.*}"
+      traefik.http.services.date.loadbalancer.server.port: 8080
     ulimits:
       rtprio:
         soft: 2
         hard: 2
     deploy:
       replicas: 3
+
   balancer:
-    # See https://docs.traefik.io/configuration/backends/docker/
     image: traefik:v2.10
-    command: --docker --docker.watch
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"      
+      - "--entrypoints.web.address=:80"
     ports:
       - "80:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro # Required because of docker backend, so traefik can get docker data.
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/.docker/docker-compose-balanced-pharo-date.yml
+++ b/.docker/docker-compose-balanced-pharo-date.yml
@@ -13,7 +13,7 @@ services:
       replicas: 3
   balancer:
     # See https://docs.traefik.io/configuration/backends/docker/
-    image: traefik:v1.7
+    image: traefik:v2.10
     command: --docker --docker.watch
     ports:
       - "80:80"

--- a/.docker/docker-compose-balanced-pharo-date.yml
+++ b/.docker/docker-compose-balanced-pharo-date.yml
@@ -9,6 +9,8 @@ services:
       rtprio:
         soft: 2
         hard: 2
+    deploy:
+      replicas: 3
   balancer:
     # See https://docs.traefik.io/configuration/backends/docker/
     image: traefik:v1.7

--- a/.docker/docker-compose-balanced-pharo-date.yml
+++ b/.docker/docker-compose-balanced-pharo-date.yml
@@ -3,8 +3,8 @@ services:
   date:
     image: pharo-date:sut
     labels:
-      traefik.enable: 'true'
-      traefik.http.routers.date.rule: "HostRegexp:{catchall:.*}"
+      traefik.http.routers.date.entryPoints: web
+      traefik.http.routers.date.rule: HostRegexp(`{host:.+}`)
       traefik.http.services.date.loadbalancer.server.port: 8080
     ulimits:
       rtprio:
@@ -14,11 +14,12 @@ services:
       replicas: 3
 
   balancer:
+    # See https://doc.traefik.io/traefik/providers/docker/
+    # See https://doc.traefik.io/traefik/reference/static-configuration/cli/
     image: traefik:v2.10
     command:
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"      
-      - "--entrypoints.web.address=:80"
+      - --providers.docker=true
+      - --entrypoints.web.address=:80
     ports:
       - "80:80"
     volumes:

--- a/.docker/docker-compose-pharo-date-multistage.yml
+++ b/.docker/docker-compose-pharo-date-multistage.yml
@@ -7,4 +7,4 @@ services:
         soft: 2
         hard: 2
     ports:
-      - 8081:8080
+      - 80:8080

--- a/.docker/docker-compose-pharo-date.yml
+++ b/.docker/docker-compose-pharo-date.yml
@@ -8,4 +8,4 @@ services:
         soft: 2
         hard: 2
     ports:
-      - 8080:8080
+      - 80:8080

--- a/.docker/docker-tests.sh
+++ b/.docker/docker-tests.sh
@@ -43,6 +43,9 @@ run_in_compose_and_test_with_curl() {
 
 set -e
 
+print_info "Pulling dependencies"
+docker pull traefik:v2.10
+
 print_info "Building base image"
 docker build --tag pharo-runtime:sut ../source
 
@@ -78,5 +81,5 @@ run_in_compose_and_test_with_curl docker-compose-pharo-date-multistage.yml
 print_success "Test #5 - Current date multistage...[OK]"
 
 print_info "Test #6 - Current date balanced"
-run_in_compose_and_test_with_curl docker-compose-balanced-pharo-date.yml 10
+run_in_compose_and_test_with_curl docker-compose-balanced-pharo-date.yml 5
 print_success "Test #6 - Current date balanced...[OK]"

--- a/.docker/docker-tests.sh
+++ b/.docker/docker-tests.sh
@@ -47,10 +47,10 @@ print_info "Pulling dependencies"
 docker pull traefik:v2.10
 
 print_info "Building base image"
-docker build --tag pharo-runtime:sut ../source
+docker buildx build --tag pharo-runtime:sut ../source
 
 print_info "Building loader base image"
-docker build \
+docker buildx build \
   --build-arg BASE_IMAGE=pharo-runtime \
   --build-arg VERSION=sut \
   --tag pharo-loader:sut \

--- a/.docker/docker-tests.sh
+++ b/.docker/docker-tests.sh
@@ -78,5 +78,5 @@ run_in_compose_and_test_with_curl docker-compose-pharo-date-multistage.yml
 print_success "Test #5 - Current date multistage...[OK]"
 
 print_info "Test #6 - Current date balanced"
-run_in_compose_and_test_with_curl docker-compose-balanced-pharo-date.yml 5
+run_in_compose_and_test_with_curl docker-compose-balanced-pharo-date.yml 10
 print_success "Test #6 - Current date balanced...[OK]"


### PR DESCRIPTION
This should make mantaining the script easier.

- Uses the `COMPOSE_FILE` instead of `--file ...`.
- Removes `COMPOSE_FILE` env var after running the test (not strictly necessary).
- Moved `--scale 3` to the compose file (now possible in newer docker versions, since we are now using `docker compose` instead of `docker-compose`)
- Standardizes the ports to 80 for easier testing on `http://localhost`.
    - Unless there is a specific reason for different ports, this is simpler.
    - If different ports are necessary, the url can be passed as an argument to the `run_in_compose_and_test_with_curl` function.
- Removes the `stop-compose` command, which is now redundant.
- Adds a new function, `run_in_compose_and_test_with_curl`.
    - Suggestions for a more descriptive name for this function are welcome.
